### PR TITLE
Add NatIp to node information

### DIFF
--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/gcp/GCPResourceModelSource.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/gcp/GCPResourceModelSource.java
@@ -16,12 +16,12 @@
 
 /*
 * GCPResourceModelSource.java
-* 
+*
 * User: James Coppens <a href="mailto:jameshcoppens@gmail.com">jameshcoppens@gmail.com</a>
 * Created: 9/1/11 4:34 PM
 * User: Glen Yu <a href="mailto:glen.yu@gmail.com">glen.yu@gmail.com</a>
 * Modified: 2018-07-11
-* 
+*
 */
 package com.dtolabs.rundeck.plugin.resources.gcp;
 
@@ -101,6 +101,7 @@ public class GCPResourceModelSource implements ResourceModelSource {
                                + "username.selector=tags/Rundeck-User\n"
                                + "username.default=rundeck\n"
                                + "internalIp.selector=networkInterfaces\n"
+                               + "natIp.selector=accessConfigs\n"
                                + "tags.selector=labels.environment|labels.osname\n"
                                + "instanceId.selector=id\n"
                                + "selfLink.selector=selfLink\n"

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/gcp/InstanceToNodeMapper.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/gcp/InstanceToNodeMapper.java
@@ -16,12 +16,12 @@
 
 /*
 * InstanceToNodeMapper.java
-* 
+*
 * User: James Coppens <a href="mailto:jameshcoppens@gmail.com">jameshcoppens@gmail.com</a>
 * Created: March 01 2016
 * User: Glen Yu <a href="mailto:glen.yu@gmail.com">glen.yu@gmail.com</a>
 * Modified: 2018-07-11
-* 
+*
 */
 package com.dtolabs.rundeck.plugin.resources.gcp;
 
@@ -44,6 +44,7 @@ import com.google.api.services.compute.model.InstanceAggregatedList;
 import com.google.api.services.compute.model.InstancesScopedList;
 import com.google.api.services.compute.model.Tags;
 import com.google.api.services.compute.model.NetworkInterface;
+import com.google.api.services.compute.model.AccessConfig;
 
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.common.INodeSet;
@@ -394,8 +395,13 @@ class InstanceToNodeMapper {
                     for (NetworkInterface netint : inst.getNetworkInterfaces()) {
                          value = netint.getNetworkIP();
                     }
-                }
-                else {
+                } else if ("accessConfigs".equals(selector)) {
+                    for (NetworkInterface netint : inst.getNetworkInterfaces()) {
+                         for (AccessConfig accconf : netint.getAccessConfigs()) {
+                             value = accconf.getNatIP();
+                          }
+                    }
+                } else {
                     value = BeanUtils.getProperty(inst, selector);
                 }
                 if (null != value) {

--- a/src/main/resources/defaultMapping.properties
+++ b/src/main/resources/defaultMapping.properties
@@ -26,6 +26,7 @@ osFamily.selector=labels.osfamily
 osName.default=unknown
 osName.selector=labels.osname
 internalIp.selector=networkInterfaces
+natIp.selector=accessConfigs
 state.selector=status
 tag.provisioning.selector=status=provisioning
 tag.staging.selector=status=staging


### PR DESCRIPTION
First, thanks so much for maintaining this code!

For our use case we really needed access to the external IP of our instances.  The changes in this PR made that possible.  Please consider merging this into master.  I based our code off your 0.2.3 release and it make take a little tweaking to get it into master.

FWIW, it does seem like the labels that you introduced along the way are mandatory and if the instances don't have them, they won't show up in rundeck.

Shout out to @jwbraucher and @mkeesey for their assistance.