### PR TITLE
Added project id in configuration file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ project.
 * Log into your Google Cloud Platform console, go to the API-Manager, then go to credentials
 * Then go to Create Credentials, Service account key.  Under the service account drop down select New Service Account. Name the service account rundeck-gcp-nodes-plugin.  Make sure the key type is JSON
 * IAM roles required: Project `Browser` & Compute Engine `Compute Viewer`  
-* rename the JSON file to `rundeck-gcp-nodes-plugin.json` and place it in /etc/rundeck/
+* Rename the JSON file to `rundeck-gcp-nodes-plugin-PROJECTID.json` and place it in /etc/rundeck/ (replace `PROJECTID` with your GCP project id)
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ You will need to add the following labels to your GCP VMs if you want more accur
 
 ## Notes
 
-By default, your conection string (denoted by the `User @ Host` column in your project nodes page) is `rundeck@hostname`, but if you want it to show IP instead you can set the `hostname.selector` attribute to `networkInterfaces` or `accessConfigs` for internal and external(NAT) IPs respectively
+By default, your connection string (denoted by the `User @ Host` column in your project nodes page) is `rundeck@hostname`, but if you want it to show IP instead you can set the `hostname.selector` attribute to `networkInterfaces` or `accessConfigs` for internal and external(NAT) IPs respectively
 
 ### Bugs/TODOs:
 
 My intention was for the labels (see "Requirements" above) to be optional with a default value provided, however that part doesn't seem to be working and if you don't have said labels, you will have no tags :( I'll look to fix that soon.
 
-`Only Running Instances` in the resouce config doesn't work, it will always report the nodes regardless of state.
+`Only Running Instances` in the resource config doesn't work, it will always report the nodes regardless of state.
 
 When Rundeck 3.1 gets released sometime down the road, that's when I'll switch development/bugfixes of this plugin to Rundeck 3.x only while just retaining the older version in the releases section...or I might split them into separate branches instead...haven't decided yet.
 

--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/gcp/GCPResourceModelSource.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/gcp/GCPResourceModelSource.java
@@ -158,7 +158,7 @@ public class GCPResourceModelSource implements ResourceModelSource {
         }
 
         try {
-            credential = GoogleCredential.fromStream(new FileInputStream("/etc/rundeck/rundeck-gcp-nodes-plugin.json"))
+            credential = GoogleCredential.fromStream(new FileInputStream("/etc/rundeck/rundeck-gcp-nodes-plugin-" + this.projectId + ".json"))
                     .createScoped(Collections.singleton(ComputeScopes.COMPUTE_READONLY));
         } catch  (FileNotFoundException e) {
             logger.error("Google Crendential failed creation");


### PR DESCRIPTION
A quick PR to add the project id in the configuration file name, in order to add several projects.

Therefore you can select GCP as node source for each GCP project you have. The configuration file name will have to be `rundeck-gcp-node-plugin-PROJECTID.json` to get the corresponding credentials.

Successfully tested on Rundeck `3.0.9`.