### PR TITLE
fix exception when no labels is set

### DIFF
--- a/src/main/java/com/dtolabs/rundeck/plugin/resources/gcp/InstanceToNodeMapper.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/resources/gcp/InstanceToNodeMapper.java
@@ -380,7 +380,11 @@ class InstanceToNodeMapper {
                          }
                     }
                 } else {
-                    value = BeanUtils.getProperty(inst, selector);
+                    try {
+                        value = BeanUtils.getProperty(inst, selector);
+                    } catch (org.apache.commons.beanutils.NestedNullException e) {
+                        // Do nothing
+                    }
                 }
                 if (null != value) {
                     return value;


### PR DESCRIPTION
Issue: When setting tags on nodes using instance labels all instances without labels are skipped.
Solution: try catch beanutils.NestedNullException