### PR TITLE
Rundeck 3.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Adds a GCP project Id to the configuration filename which allows the user to add additional `GCP GCE Resources` as Node Sources to see the inventory of multiple projects.  Thanks to [ogerbron](https://github.com/ogerbron) for this [PR](https://github.com/Neutrollized/rundeck-gcp-nodes-plugin/pull/2)!
 ### Changed
-- Versioning!  This will be the last release built with a rundeck-core of v2.x (except for bug fixes); future releases will be using rundeck-core of the v3.x variety.
+- Versioning update!  The version number will correspond to the rundeck-core I'm using to build the release.  This way, users can download the latest-and-greatest plugin version to match their Rundeck version.  However, this will be the last release built with a rundeck-core of v2.x (except for bug fixes); future releases will be using rundeck-core of the v3.x variety.
 
 ## [0.3.0] - 2018-08-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.9-1] - 2018-12-30
+### Changed
+- updated `gradle` to `4.10.3`
+- updated `axion-release plugin` to `1.10.0`
+- updated `rundeck-core` to `3.0.9-20181127`
+
 ## [2.7.1-1] - 2018-12-17
 ### Added
 - Adds a GCP project Id to the configuration filename which allows the user to add additional `GCP GCE Resources` as Node Sources to see the inventory of multiple projects.  Thanks to [ogerbron](https://github.com/ogerbron) for this [PR](https://github.com/Neutrollized/rundeck-gcp-nodes-plugin/pull/2)!

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 This is a Resource Model Source plugin for [Rundeck](https://www.rundeck.org) 3.0.9+ that provides Google Cloud Platform GCE Instances as nodes for the Rundeck Server.
 
+If you're still running Rundeck v2.x, please use one of the releases labeled v2.7.1-2 or earlier.
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ By default, your connection string (denoted by the `User @ Host` column in your 
 
 ### Bugs/TODOs:
 
-My intention was for the labels (see "Requirements" above) to be optional with a default value provided, however that part doesn't seem to be working and if you don't have said labels, you will have no tags :( I'll look to fix that soon.
-
 `Only Running Instances` in the resource config doesn't work, it will always report the nodes regardless of state.
 
 When Rundeck 3.1 gets released sometime down the road, that's when I'll switch development/bugfixes of this plugin to Rundeck 3.x only while just retaining the older version in the releases section...or I might split them into separate branches instead...haven't decided yet.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,19 @@
-[![Build Status](https://travis-ci.org/Neutrollized/rundeck-gcp-nodes-plugin.svg?branch=rundeck-2.7.1)](https://travis-ci.org/Neutrollized/rundeck-gcp-nodes-plugin)
+[![Build Status](https://travis-ci.org/Neutrollized/rundeck-gcp-nodes-plugin.svg?branch=rundeck-3.0.9)](https://travis-ci.org/Neutrollized/rundeck-gcp-nodes-plugin)
 [![Code Climate](https://codeclimate.com/github/Neutrollized/rundeck-gcp-nodes-plugin.png)](https://codeclimate.com/github/Neutrollized/rundeck-gcp-nodes-plugin)
 
 # Rundeck GCP Nodes Plugin
-[![GitHub release](https://img.shields.io/badge/release-v2.7.1--1-blue.svg)](https://github.com/Neutrollized/rundeck-gcp-nodes-plugin/releases)
+[![GitHub release](https://img.shields.io/badge/release-v3.0.9--1-blue.svg)](https://github.com/Neutrollized/rundeck-gcp-nodes-plugin/releases)
 
 ### [CHANGELOG](https://github.com/Neutrollized/rundeck-gcp-nodes-plugin/blob/master/CHANGELOG.md)
 
-** I will not be making further changes to this branch (other than bug fixes) after this release for Rundeck v2.x.  I will also be making a new branch/updating master with the plugin using a newer rundeck-core and will also take this opportunity to redo the versioning scheme :) **
-
-This is a Resource Model Source plugin for [Rundeck](https://www.rundeck.org) 2.7.1+ that provides
-Google Cloud Platform GCE Instances as nodes for the Rundeck server.
-
-Confirmed to work for Rundeck up to current latest (v3.0.9)
+This is a Resource Model Source plugin for [Rundeck](https://www.rundeck.org) 3.0.9+ that provides Google Cloud Platform GCE Instances as nodes for the Rundeck Server.
 
 
 ## Installation
 
 Download from the [releases page](https://github.com/Neutrollized/rundeck-gcp-nodes-plugin/releases).
 
-Put the `rundeck-gcp-nodes-plugin-2.7.1.jar` into your `$RDECK_BASE/libext` dir.
+Put the `rundeck-gcp-nodes-plugin-3.0.9-1.jar` into your `$RDECK_BASE/libext` dir.
 
 You must also authenticate the rundeck-gcp-nodes-plugin to your google cloud platform
 project.
@@ -52,16 +47,6 @@ When Rundeck 3.1 gets released sometime down the road, that's when I'll switch d
 ### Disclaimer
 
 My work is built off of the work done by [jameshcoppens](https://github.com/jameshcoppens/rundeck-gcp-nodes-plugin) and I've only branched it off to updated/maintain it seeing as there are typos in the README that has gone unaddressed and hasn't been updated for ~2+ years.  There were some functionality/features I wanted to add for my own use (and at work) so here we are... :)
-
-
-### What I've done so far...
-
-* fixed the documentation for installing the plugin
-* changed the fields that get populated when you expand a node in Rundeck as some in the original plugin just wasn't working or was putting in wrong values
-* updated `rundeck-core` to `2.7.1`, `rundeckPluginVersion` to `1.2` and `google-api-servies-compute` plugins
-* cleaned up the code to remove any AWS references in the code as well as plugins that aren't used (as it was initially modified off of [Rundeck's EC2 nodes plugin](https://github.com/rundeck-plugins/rundeck-ec2-nodes-plugin))
-* reduced the .jar file size from ~8MB to ~5.5MB
-* improved maintainability and readability
 
 
 ## !!! PRs welcome as I'm still new at this (my Java sucks)!!!

--- a/README.md
+++ b/README.md
@@ -39,11 +39,10 @@ You will need to add the following labels to your GCP VMs if you want more accur
 
 By default, your connection string (denoted by the `User @ Host` column in your project nodes page) is `rundeck@hostname`, but if you want it to show IP instead you can set the `hostname.selector` attribute to `networkInterfaces` or `accessConfigs` for internal and external(NAT) IPs respectively
 
+
 ### Bugs/TODOs:
 
 `Only Running Instances` in the resource config doesn't work, it will always report the nodes regardless of state.
-
-When Rundeck 3.1 gets released sometime down the road, that's when I'll switch development/bugfixes of this plugin to Rundeck 3.x only while just retaining the older version in the releases section...or I might split them into separate branches instead...haven't decided yet.
 
 
 ### Disclaimer

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    id 'pl.allegro.tech.build.axion-release' version '1.9.2'
+    id 'pl.allegro.tech.build.axion-release' version '1.10.0'
 }
 
 apply plugin: 'java'
@@ -54,7 +54,7 @@ repositories {
 }
 dependencies {
     // https://mvnrepository.com/artifact/org.rundeck/rundeck-core
-    compile group: 'org.rundeck', name: 'rundeck-core', version: '2.7.1'
+    compile group: 'org.rundeck', name: 'rundeck-core', version: '3.0.9-20181127'
 
     pluginLibs group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.3'
     pluginLibs group: 'dom4j', name: 'dom4j', version: '1.6.1'
@@ -81,8 +81,8 @@ jar {
         // create space-separated list of pluginLibs
         def libList = configurations.pluginLibs.collect{'lib/'+it.name}.join(' ')
         attributes 'Rundeck-Plugin-Classnames': 'com.dtolabs.rundeck.plugin.resources.gcp.GCPResourceModelSourceFactory', 'Rundeck-Plugin-Libs': "${libList}"
-        attributes 'Rundeck-Plugin-Author': 'Glen Yu', 'Rundeck-Plugin-URL': 'https://github.com/Neutrollized/rundeck-gcp-nodes-plugin', 'Rundeck-Plugin-Date': '2018-12-17'
-        attributes 'Rundeck-Plugin-File-Version': '2.7.1-1'
+        attributes 'Rundeck-Plugin-Author': 'Glen Yu', 'Rundeck-Plugin-URL': 'https://github.com/Neutrollized/rundeck-gcp-nodes-plugin', 'Rundeck-Plugin-Date': '2018-12-30'
+        attributes 'Rundeck-Plugin-File-Version': '3.0.9-1'
     }
 }
 
@@ -90,5 +90,5 @@ jar {
 jar.dependsOn(copyToLib)
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.7'
+    gradleVersion = '4.10.3'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Oct 15 11:11:38 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-4.10.3-bin.zip


### PR DESCRIPTION
- updated rundeck-core to 3.0.9-20181127
- for Rundeck v2.x, please use releases v2.7.1-2 or earlier, or see the rundeck-2.7.1 branch